### PR TITLE
Test route added to test connection with Supabase DB

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,23 @@
+import express from 'express';
+import cors from 'cors';
+
+import { userRoutes } from './routes/userRoutes.ts';
+import { testDBRoutes } from './routes/testDBRoutes.ts';
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.use('/users', userRoutes);
+app.use('/api', testDBRoutes);
+
+app.get('/api/hello', (_req, res) => {
+  res.json({ message: 'Hello from the backend!' });
+});
+
+app.get('/', (_req, res) => {
+  res.send('API is running');
+});
+
+export default app;

--- a/src/controllers/dbtestController.ts
+++ b/src/controllers/dbtestController.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express';
+import { supabase } from '../config/supabaseClient.ts';
+
+export async function testDBConnection(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<void> {
+  try {
+    const { data, error } = await supabase
+      .from('Users')
+      .select('*')
+      .limit(1);
+
+    if (error) {
+      console.error('❌ Supabase error:', error);
+      res.status(500).json({ success: false, error: error.message });
+    }
+
+    res.json({ success: true, data });
+  } catch (err) {
+    next?.(err);
+  }
+}

--- a/src/routes/testDBRoutes.ts
+++ b/src/routes/testDBRoutes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+const router = express.Router();
+
+import { testDBConnection } from '../controllers/dbtestController.ts';
+
+router.get('/test-db', testDBConnection);
+
+export { router as testDBRoutes };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,19 +1,6 @@
-import express from 'express';
-import cors from 'cors';
+import app from './app.ts';
 
-const app = express();
 const PORT = 5000;
-
-app.use(cors());
-app.use(express.json());
-
-import { userRoutes } from './routes/userRoutes.ts';
-
-app.use('/users', userRoutes);
-
-app.get('/api/hello', (_req, res) => {
-  res.json({ message: 'Hello from the backend!' });
-});
 
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */
@@ -26,9 +26,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "ESNext" /* Specify what module code is generated. */,
+    "module": "ESNext",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "Node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+     "moduleResolution": "Node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -36,13 +36,13 @@
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    "allowImportingTsExtensions": true /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */,
+     "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
     // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
     // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
-    "resolveJsonModule": true /* Enable importing .json files. */,
+     "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
@@ -57,7 +57,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    "noEmit": true /* Disable emitting files from a compilation. */,
+     "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
@@ -80,12 +80,12 @@
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
-    "strict": false /* Enable all strict type-checking options. */,
+    "strict": false,                                      /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -108,7 +108,7 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## 📌 Summary

Added test route to connect Supabase DB and our node backend. 

New files added are:
controllers - dbtestControllers.ts
routes - testDBRoutes.ts

Added app.ts and edited server.ts

Supabase tables have been updated:

![image](https://github.com/user-attachments/assets/3ad5f389-73b0-4d2a-824d-d58607279ced)


---

## 🔍 Related Issues

Closes #6

---

## 🧪 How to Test

1. Run `npm install` to ensure latest dependencies are updated. 
2. Run `npm run dev`
3. Navigate to `http://localhost:5000/api/test-db` - This will run the test-db route which will extract a dummy user from the Supabase DB. 

Expected outcome is:

![image](https://github.com/user-attachments/assets/fbf6810f-080e-4f47-8209-bcea819167d7)


---

## 🧠 Notes for Reviewers

One weird thing I've found is that .ts is needed at the end of imports - @chrislush we got conflicting advice from chatgpt around this but adding the .ts was the only way to remove errors. 

![image](https://github.com/user-attachments/assets/b7976eaa-8e0b-4836-bf1c-2453e058c1d2)
![image](https://github.com/user-attachments/assets/ba2b65c9-5960-433f-a3ac-1af73e3155e3)

